### PR TITLE
Add starter template for OpenAPI configuration

### DIFF
--- a/workflow-templates/openapi-linting.properties.json
+++ b/workflow-templates/openapi-linting.properties.json
@@ -1,0 +1,4 @@
+{
+  "name": "OpenAPI Linting",
+  "description": "Ensure that your OpenAPI / Swagger documentation matches standards across Deliveroo"
+}

--- a/workflow-templates/openapi-linting.yml
+++ b/workflow-templates/openapi-linting.yml
@@ -1,0 +1,26 @@
+name: "Lint OpenAPI specifications"
+on:
+  push:
+    paths:
+      - .github/workflows/openapi-linting.yml
+      # TODO: update me according to how your repo is set up
+      - docs/openapi.yml
+      - openapi.yml
+      - openapi.yaml
+      - swagger.yml
+  pull_request:
+    paths:
+      - .github/workflows/openapi-linting.yml
+      # TODO: update me according to how your repo is set up
+      - docs/openapi.yml
+      - openapi.yml
+      - openapi.yaml
+      - swagger.yml
+permissions:
+  contents: read
+jobs:
+  validate-config:
+    uses: deliveroo/api-linting-tooling/.github/workflows/reusable-openapi-linting.yml@main
+    with:
+      # TODO: update me according to how your repo is set up
+      globs: ./docs/openapi.yml


### PR DESCRIPTION
To simplify setup for folks - as it presents itself in the UI for folks
adding it to repos - we can create a starter template for the shared
OpenAPI linting tooling.

This still uses the reusable workflow, so as little configuration as
possible is duplicated across projects.
